### PR TITLE
Add RT-DETR training example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# RT-DETR Training
+
+This repository contains a minimal example for training a Real-Time Detection Transformer (RT-DETR) model using PyTorch. The main script is `train_rtdetr.py` which demonstrates loading the COCO dataset and training a simplified RT-DETR model.
+
+```
+python train_rtdetr.py --data-path /path/to/coco --epochs 10 --batch-size 2
+```
+
+The provided `RTDETRModel` is a placeholder. For real experiments, replace it with an actual implementation from an RT-DETR library or your custom model definition.

--- a/train_rtdetr.py
+++ b/train_rtdetr.py
@@ -1,0 +1,80 @@
+import argparse
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from torch.utils.data import DataLoader
+from torchvision import transforms
+from torchvision.datasets import CocoDetection
+
+# Placeholder for RT-DETR model. In practice you should import
+# an implementation from an RT-DETR library or define the model here.
+class RTDETRModel(nn.Module):
+    def __init__(self, num_classes=80):
+        super().__init__()
+        # TODO: replace this with actual RT-DETR implementation
+        self.backbone = nn.Conv2d(3, 16, kernel_size=3, stride=1, padding=1)
+        self.classifier = nn.Linear(16, num_classes)
+
+    def forward(self, images):
+        # Simplified forward pass
+        x = self.backbone(images)
+        x = x.mean([2, 3])
+        logits = self.classifier(x)
+        return logits
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="RT-DETR Training Script")
+    parser.add_argument('--data-path', type=str, required=True,
+                        help='Path to COCO dataset root')
+    parser.add_argument('--epochs', type=int, default=10, help='Number of training epochs')
+    parser.add_argument('--batch-size', type=int, default=2, help='Batch size')
+    parser.add_argument('--lr', type=float, default=1e-4, help='Learning rate')
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    transform = transforms.Compose([
+        transforms.ToTensor(),
+    ])
+
+    # COCO dataset
+    train_dataset = CocoDetection(
+        root=f"{args.data_path}/train2017",
+        annFile=f"{args.data_path}/annotations/instances_train2017.json",
+        transform=transform,
+    )
+
+    train_loader = DataLoader(train_dataset, batch_size=args.batch_size, shuffle=True,
+                              collate_fn=lambda x: tuple(zip(*x)))
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = RTDETRModel().to(device)
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.Adam(model.parameters(), lr=args.lr)
+
+    for epoch in range(args.epochs):
+        model.train()
+        running_loss = 0.0
+        for images, targets in train_loader:
+            images = torch.stack(images).to(device)
+            # For demonstration, this example uses the first object's label
+            labels = torch.tensor([t[0]['category_id'] for t in targets]).to(device)
+
+            optimizer.zero_grad()
+            outputs = model(images)
+            loss = criterion(outputs, labels)
+            loss.backward()
+            optimizer.step()
+            running_loss += loss.item()
+
+        print(f"Epoch {epoch+1}/{args.epochs}, Loss: {running_loss/len(train_loader):.4f}")
+
+    print('Training complete')
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
## Summary
- add README with basic instructions
- add `train_rtdetr.py` script showing a minimal RT-DETR training pipeline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68586295cf6c8332983c162dd450a164